### PR TITLE
fixing bug that error is produced if user doesnt specify paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 versions here coincide with releases on pypi.
 
 ## [master](https://github.com/openbases/openbases-python/tree/master)
+ - validation shouldn't continue if paper doesn't exist (0.0.54)
  - papers module validation functions (0.0.53)
  - adding color for "spec" (specification) to match schema.org (0.0.52)
  - adding custom color specification (0.0.51)

--- a/openbases/cli/validate/paper.py
+++ b/openbases/cli/validate/paper.py
@@ -24,6 +24,8 @@ def main(args, options=None):
 
     # Ensure that paper exists
     paper = args.infile
+    if not paper:
+        bot.exit('You must specify a paper with --infile')
     if not os.path.exists(paper):
         bot.exit('%s does not exist.' % paper)
     paper = os.path.abspath(paper)     

--- a/openbases/version.py
+++ b/openbases/version.py
@@ -2,7 +2,7 @@
 # See the LICENSE in the main repository at:
 #    https://www.github.com/openbases/openbases-python
 
-__version__ = "0.0.53"
+__version__ = "0.0.54"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'openbases'


### PR DESCRIPTION
This will fix what I consider a bug that if the user runs "validate" without a paper, it bugs out because it does a check for the path (which is none) and you can't do that :)